### PR TITLE
refactor: style token extenders

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mc-color",
   "displayName": "Minecraft Color Highlighter",
   "description": "Highlight Minecraft colors in your editor",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "publisher": "Nobuwu",
   "license": "MIT",
   "main": "./dist/extension.js",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -50,7 +50,7 @@ function isValidDocument(config: Config, { languageId }: vscode.TextDocument): b
 	}
 
 	// If config languages contains (*) then files clearly okay
-	if ((config?.langauges?.indexOf('*') ?? []) > -1) {
+	if ((config?.langauges?.indexOf('*') ?? -1) > -1) {
 		isValid = true
 	}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import { Highlight } from './Highlight'
 export type MarkerType = 'foreground' | 'background' | 'outline' | 'underline'
 export interface Config extends vscode.WorkspaceConfiguration {
 	enabled?: boolean,
-	langauges?: string[],
+	languages?: string[],
 	markerType?: MarkerType
 	prefixes?: string[]
 	delimiters?: string[]
@@ -50,7 +50,7 @@ function isValidDocument(config: Config, { languageId }: vscode.TextDocument): b
 	}
 
 	// If config languages contains (*) then files clearly okay
-	if ((config?.langauges?.indexOf('*') ?? -1) > -1) {
+	if ((config?.languages?.indexOf('*') ?? -1) > -1) {
 		isValid = true
 	}
 


### PR DESCRIPTION
To understand how the formatting extension issue was resolved, let's dive into how formatting text works in VSCode.
Formatting code in VSCode is simple - a file is a string, so we can select a specific area with two indices. To format, provide a range and CSS styles, and VSCode will apply them automatically.
Moving on to the highlighter in mc-color, a method fetches the index of every position your set prefixes appear in the file. We loop through these indices and find the next delimiter from the start index. We then set the style start and end index, and color/format in an array. After this, we run two methods to extend previous formats/colors to the newest delimiter.
The issue lay in the logic treating delimiters like prefixes, causing it to pass-through delimiters if a prefix came after it. To fix it, we refactored the loop and added a check under the color/format clauses. If the current end index character is a delimiter, we append a reset token to the style array.
Now, the format/color extenders only run after the tokenization process, making it more efficient. In short, the shit code has been refactored now that we see the issue.

This PR Also fixes some other small issues related to config options not working due to never tested 👍 

Thank you @Felix14-v2 for making an issue; Here is your file shown as supposed to be:
![image](https://user-images.githubusercontent.com/61068742/237019817-17e1d557-d18a-453e-af1f-5ab7572d9a8a.png)

